### PR TITLE
Update usage to reflect expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,4 @@ jobs:
       name: my-container
       tag: ${GITHUB_REF_NAME}
       dockerfile_path: path/to/Dockerfile
-
-  # Push to latest
-  container-push-latest:
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
-    with:
-      name: my-container
-      tag: latest
-      dockerfile_path: path/to/Dockerfile
 ```


### PR DESCRIPTION
We currently cannot sign and set provenance for a container in more than
one subsequent step on the same git reference... this is a bug and it
has been noted.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
