### PR TITLE
Make registry org configurable

### DIFF
--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -11,6 +11,11 @@ on:
         description: 'Container image tag to push. Normally it will be the GITHUB_REF_NAME env variable'
         required: true
         type: string
+      registry_org:
+        description: 'The registry organization to push to'
+        default: '${{ github.repository_owner }}'
+        required: false
+        type: string
       dockerfile_path:
         description: 'The relative path to the Dockerfile to build.'
         default: 'Dockerfile'
@@ -62,8 +67,8 @@ jobs:
           revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
           docker build \
             -f ${{ inputs.dockerfile_path }} \
-            -t "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}:${{ inputs.tag }}" \
-            -t "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}:${revision}" \
+            -t "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}" \
+            -t "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" \
             --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
             --label "org.opencontainers.image.created=$(date --iso-8601=seconds)" \
             --label "org.opencontainers.image.title=${{ inputs.name }}" \
@@ -74,13 +79,13 @@ jobs:
             ${{ inputs.build_context }}
 
       - name: Publish Container images
-        run: docker push "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}" --all-tags
+        run: docker push "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}" --all-tags
 
       - name: Get container info
         id: container_info
         run: |
           revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
-          image_digest="$(docker inspect "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}:${revision}" --format '{{ index .RepoDigests 0 }}' | awk -F '@' '{ print $2 }')"
+          image_digest="$(docker inspect "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" --format '{{ index .RepoDigests 0 }}' | awk -F '@' '{ print $2 }')"
           image_tags="${{ inputs.tag }},$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
           echo "::set-output name=image-digest::${image_digest}"
           echo "::set-output name=image-tags::${image_tags}"
@@ -109,10 +114,10 @@ jobs:
 
       - name: Sign image
         run: |
-          cosign sign "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST}"
-          echo "::notice title=Verify signature::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.[0]'"
-          echo "::notice title=Inspect signature bundle::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.[0].optional.Bundle.Payload.body |= @base64d | .[0].optional.Bundle.Payload.body | fromjson'"
-          echo "::notice title=Inspect certificate::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST} | jq -r '.[0].optional.Bundle.Payload.body |= @base64d | .[0].optional.Bundle.Payload.body | fromjson | .spec.signature.publicKey.content |= @base64d | .spec.signature.publicKey.content' | openssl x509 -text"
+          cosign sign "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
+          echo "::notice title=Verify signature::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.[0]'"
+          echo "::notice title=Inspect signature bundle::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.[0].optional.Bundle.Payload.body |= @base64d | .[0].optional.Bundle.Payload.body | fromjson'"
+          echo "::notice title=Inspect certificate::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq -r '.[0].optional.Bundle.Payload.body |= @base64d | .[0].optional.Bundle.Payload.body | fromjson | .spec.signature.publicKey.content |= @base64d | .spec.signature.publicKey.content' | openssl x509 -text"
 
   sbom:
     runs-on: ubuntu-latest
@@ -141,9 +146,9 @@ jobs:
 
       - name: Attach SBOM to image
         run: |
-          syft "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST}" -o spdx-json=sbom-spdx.json
-          cosign attest --predicate sbom-spdx.json --type spdx "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST}"
-          echo "::notice title=Verify SBOM attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://spdx.dev/Document\") | .predicate.Data | fromjson'"
+          syft "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}" -o spdx-json=sbom-spdx.json
+          cosign attest --predicate sbom-spdx.json --type spdx "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
+          echo "::notice title=Verify SBOM attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://spdx.dev/Document\") | .predicate.Data | fromjson'"
 
   provenance:
     runs-on: ubuntu-latest
@@ -166,7 +171,7 @@ jobs:
         with:
           command: generate
           subcommand: container
-          arguments: --repository "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}" --output-path "${PROVENANCE_FILE}" --digest "${IMAGE_DIGEST}" --tags "${IMAGE_TAGS}"
+          arguments: --repository "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}" --output-path "${PROVENANCE_FILE}" --digest "${IMAGE_DIGEST}" --tags "${IMAGE_TAGS}"
         env:
           COSIGN_EXPERIMENTAL: 0
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -182,5 +187,5 @@ jobs:
       - name: Attach provenance
         run: |
           jq '.predicate' "${PROVENANCE_FILE}" > provenance-predicate.att
-          cosign attest --predicate provenance-predicate.att --type slsaprovenance "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST}"
-          echo "::notice title=Verify provenance attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://slsa.dev/provenance/v0.2\")'"
+          cosign attest --predicate provenance-predicate.att --type slsaprovenance "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
+          echo "::notice title=Verify provenance attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://slsa.dev/provenance/v0.2\")'"


### PR DESCRIPTION
This ensures that one is able to set the registry org manually (this is
useful for cases where the GitHub org is in a format that's not friendly
to Docker registries. By making this configurable we can just ignore
this and allow folks to set this as needed.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
