### PR TITLE
Login to GHCR before generating provenance

### DIFF
--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -166,6 +166,13 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v2.3.0
 
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate provenance
         uses: philips-labs/slsa-provenance-action@v0.7.2
         with:
@@ -176,13 +183,6 @@ jobs:
           COSIGN_EXPERIMENTAL: 0
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           IMAGE_TAGS: ${{ needs.container.outputs.image-tags }}
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v2.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attach provenance
         run: |


### PR DESCRIPTION
We were getting authentication issues, and this attempts to log in
beforehand to avoid these.

Related Bug: https://github.com/ComplianceAsCode/content/issues/8851

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
