### PR TITLE
github: Add permission to read internal repo

### DIFF
--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -46,6 +46,7 @@ jobs:
 
     permissions:
       packages: write
+      contents: read
 
     outputs:
       image-digest: ${{ steps.container_info.outputs.image-digest }}


### PR DESCRIPTION
Extends the permission given to `container` job so it can read internal repositories.