### PR TITLE
Add multi-arch support for container-push

### DIFF
--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -90,7 +90,6 @@ jobs:
           labels: |
             org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
             org.opencontainers.image.title=${{ inputs.name }}
-            org.opencontainers.image.revision=${revision}
             org.opencontainers.image.version=${{ inputs.tag }}
             org.opencontainers.image.licenses=${{ inputs.licenses }}
             org.opencontainers.image.vendor=${{ inputs.vendor }}
@@ -107,13 +106,11 @@ jobs:
 
       - name: Fetch container locally
         run: |
-          revision="$(git rev-parse HEAD)"
-          docker pull "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}"
+          docker pull "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}"
 
       - name: Tag latest
         run: |
-          revision="$(git rev-parse HEAD)"
-          docker tag "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:latest"
+          docker tag "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}" "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:latest"
         if: ${{ inputs.latest }}
 
       - name: Publish Container images (latest)
@@ -123,8 +120,7 @@ jobs:
       - name: Get container info
         id: container_info
         run: |
-          revision="$(git rev-parse HEAD)"
-          image_digest="$(docker inspect "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" --format '{{ index .RepoDigests 0 }}' | awk -F '@' '{ print $2 }')"
+          image_digest="$(docker inspect "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}" --format '{{ index .RepoDigests 0 }}' | awk -F '@' '{ print $2 }')"
           image_tags="${{ inputs.tag }},$(git rev-parse HEAD)"
           echo "::set-output name=image-digest::${image_digest}"
           echo "::set-output name=image-tags::${image_tags}"

--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -107,12 +107,12 @@ jobs:
 
       - name: Fetch container locally
         run: |
-          revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
+          revision="$(git rev-parse HEAD)"
           docker pull "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}"
 
       - name: Tag latest
         run: |
-          revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
+          revision="$(git rev-parse HEAD)"
           docker tag "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:latest"
         if: ${{ inputs.latest }}
 
@@ -123,9 +123,9 @@ jobs:
       - name: Get container info
         id: container_info
         run: |
-          revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
+          revision="$(git rev-parse HEAD)"
           image_digest="$(docker inspect "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" --format '{{ index .RepoDigests 0 }}' | awk -F '@' '{ print $2 }')"
-          image_tags="${{ inputs.tag }},$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
+          image_tags="${{ inputs.tag }},$(git rev-parse HEAD)"
           echo "::set-output name=image-digest::${image_digest}"
           echo "::set-output name=image-tags::${image_tags}"
 

--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -41,6 +41,11 @@ on:
         default: 'Equinix, Inc.'
         required: false
         type: string
+      platforms:
+        description: 'The platforms to build the container for.'
+        default: 'linux/amd64'
+        required: false
+        type: string
 
 env:
   COSIGN_EXPERIMENTAL: 1
@@ -68,30 +73,52 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build container images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+            type=sha,format=long
+          labels: |
+            org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+            org.opencontainers.image.title=${{ inputs.name }}
+            org.opencontainers.image.revision=${revision}
+            org.opencontainers.image.version=${{ inputs.tag }}
+            org.opencontainers.image.licenses=${{ inputs.licenses }}
+            org.opencontainers.image.vendor=${{ inputs.vendor }}
+
+      - name: Build container images and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ inputs.build_context }}
+          file: ${{ inputs.dockerfile_path }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          platforms: ${{ inputs.platforms }}
+
+      - name: Fetch container locally
         run: |
           revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
-          docker build \
-            -f ${{ inputs.dockerfile_path }} \
-            -t "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}" \
-            -t "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" \
-            --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
-            --label "org.opencontainers.image.created=$(date --iso-8601=seconds)" \
-            --label "org.opencontainers.image.title=${{ inputs.name }}" \
-            --label "org.opencontainers.image.revision=${revision}" \
-            --label "org.opencontainers.image.version=${{ inputs.tag }}" \
-            --label "org.opencontainers.image.licenses=${{ inputs.licenses }}" \
-            --label "org.opencontainers.image.vendor=${{ inputs.vendor }}" \
-            ${{ inputs.build_context }}
-      
+          docker pull "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}"
+
       - name: Tag latest
         run: |
           revision="$(git rev-parse "${GITHUB_REF_NAME:-HEAD}")"
           docker tag "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${revision}" "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:latest"
         if: ${{ inputs.latest }}
 
-      - name: Publish Container images
+      - name: Publish Container images (latest)
         run: docker push "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}" --all-tags
+        if: ${{ inputs.latest }}
 
       - name: Get container info
         id: container_info

--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -87,6 +87,7 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.tag }}
             type=sha,format=long
+            type=raw,value=latest,enable=${{ inputs.latest }}
           labels: |
             org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
             org.opencontainers.image.title=${{ inputs.name }}
@@ -107,15 +108,6 @@ jobs:
       - name: Fetch container locally
         run: |
           docker pull "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}"
-
-      - name: Tag latest
-        run: |
-          docker tag "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}" "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:latest"
-        if: ${{ inputs.latest }}
-
-      - name: Publish Container images (latest)
-        run: docker push "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}" --all-tags
-        if: ${{ inputs.latest }}
 
       - name: Get container info
         id: container_info

--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -121,7 +121,7 @@ jobs:
         id: container_info
         run: |
           image_digest="$(docker inspect "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}:${{ inputs.tag }}" --format '{{ index .RepoDigests 0 }}' | awk -F '@' '{ print $2 }')"
-          image_tags="${{ inputs.tag }},$(git rev-parse HEAD)"
+          image_tags="${{ inputs.tag }},sha-$(git rev-parse HEAD)"
           echo "::set-output name=image-digest::${image_digest}"
           echo "::set-output name=image-tags::${image_tags}"
 


### PR DESCRIPTION
This ensures that we're able to build for multiple architectures using
container-push. To do this, we switched to using buildx/qemu, as well as
using the supported docker GH actions.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
