### PR TITLE
cosign: auto accept prompts

### DIFF
--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Sign image
         run: |
-          cosign sign "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
+          cosign sign -y "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
           echo "::notice title=Verify signature::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.[0]'"
           echo "::notice title=Inspect signature bundle::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.[0].optional.Bundle.Payload.body |= @base64d | .[0].optional.Bundle.Payload.body | fromjson'"
           echo "::notice title=Inspect certificate::COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq -r '.[0].optional.Bundle.Payload.body |= @base64d | .[0].optional.Bundle.Payload.body | fromjson | .spec.signature.publicKey.content |= @base64d | .spec.signature.publicKey.content' | openssl x509 -text"
@@ -174,7 +174,7 @@ jobs:
       - name: Attach SBOM to image
         run: |
           syft "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}" -o spdx-json=sbom-spdx.json
-          cosign attest --predicate sbom-spdx.json --type spdx "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
+          cosign attest -y --predicate sbom-spdx.json --type spdx "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
           echo "::notice title=Verify SBOM attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://spdx.dev/Document\") | .predicate.Data | fromjson'"
 
   provenance:
@@ -214,5 +214,5 @@ jobs:
       - name: Attach provenance
         run: |
           jq '.predicate' "${PROVENANCE_FILE}" > provenance-predicate.att
-          cosign attest --predicate provenance-predicate.att --type slsaprovenance "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
+          cosign attest -y --predicate provenance-predicate.att --type slsaprovenance "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
           echo "::notice title=Verify provenance attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://slsa.dev/provenance/v0.2\")'"


### PR DESCRIPTION
We were not using the `-y` option and builds are now failing. We need to
add the `-y` flag as we're not running this in an interactive
environment.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
