### PR TITLE
Support multi-arch for SBOM

### DIFF
--- a/.github/workflows/container-push.yml
+++ b/.github/workflows/container-push.yml
@@ -204,6 +204,6 @@ jobs:
 
       - name: Attach SBOM to image
         run: |
-          syft "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}" -o spdx-json=sbom-spdx.json
+          syft --platform ${{ inputs.platforms }} "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}" -o spdx-json=sbom-spdx.json
           cosign attest -y --predicate sbom-spdx.json --type spdx "ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST}"
           echo "::notice title=Verify SBOM attestation::COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/${{ inputs.registry_org }}/${{ inputs.name }}@${IMAGE_DIGEST} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://spdx.dev/Document\") | .predicate.Data | fromjson'"


### PR DESCRIPTION
This will help us to be able to fix sbom failures when building for multi-arch, we need to set --platform in order to run syft on any other arch other amd64.

```
[vincent@node compliance-operator]$ syft ghcr.io/complianceascode/compliance-operator-bundle@sha256:5d8e6f9c3612c6ad0f6c6cfb8dd4471e48a7300e9b79d322a10f4783be0c18e6 -o spdx-json=sbom-spdx.json
 ✔ Pulled image                    
could not determine source: errors occurred attempting to resolve 'ghcr.io/complianceascode/compliance-operator-bundle@sha256:5d8e6f9c3612c6ad0f6c6cfb8dd4471e48a7300e9b79d322a10f4783be0c18e6':
  - docker: unable to inspect existing image: Error response from daemon: No such image: ghcr.io/complianceascode/compliance-operator-bundle@sha256:5d8e6f9c3612c6ad0f6c6cfb8dd4471e48a7300e9b79d322a10f4783be0c18e6
  - podman: podman not available: no host address
  - containerd: containerd not available: no grpc connection or services is available: unavailable
  - oci-registry: failed to get image from registry: no child with platform linux/amd64 in index ghcr.io/complianceascode/compliance-operator-bundle@sha256:5d8e6f9c3612c6ad0f6c6cfb8dd4471e48a7300e9b79d322a10f4783be0c18e6
  - additionally, the following providers failed with file does not exist: docker-archive, oci-archive, oci-dir, singularity, oci-dir, local-file, local-directory
  ```

Can be fixed with 
```
[vincent@node compliance-operator]$ syft --platform linux/ppc64le ghcr.io/complianceascode/compliance-operator-bundle@sha256:5d8e6f9c3612c6
ad0f6c6cfb8dd4471e48a7300e9b79d322a10f4783be0c18e6 -o spdx-json=sbom-spdx.json
 ⠇ Pulling image                   3 Layers▕███▏[32 kB / 32 kB]  
```